### PR TITLE
Fallback to package.Id if title not available

### DIFF
--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -732,7 +732,7 @@ namespace Squirrel.Update
             var templateText = File.ReadAllText(Path.Combine(pathToWix, "template.wxs"));
             var templateData = new Dictionary<string, string> {
                 { "Id", package.Id },
-                { "Title", package.Title },
+                { "Title", package.Title ?? package.Id },
                 { "Author", company },
                 { "Version", Regex.Replace(package.Version.ToString(), @"-.*$", "") },
                 { "Summary", package.Summary ?? package.Description ?? package.Id },


### PR DESCRIPTION
If a package title is not set in the nuspec tile, normal user installs work fine, but the installation folder set in the Wix for the machine wide installer becomes "%programfiles%\ Installer\ .... " - note the space where the title should be. 

When the folder is created this space is silently removed by the operating system, however in the registry Run entry, the space is present. As the name in the registry and the actual path don't match, the machine wide installer never runs. 

This change means that the installer falls back to using the id if the name is not available